### PR TITLE
좋아요한 게시글 페이지 구현

### DIFF
--- a/src/pages/articleDetail/ArticleDetailPage.vue
+++ b/src/pages/articleDetail/ArticleDetailPage.vue
@@ -31,6 +31,7 @@
         @delete-reply="handleDeleteReply"
         @report-comment="openReportCommentModal"
         @add-region="handleAddRegion"
+        @remove-region="handleRemoveRegion"
       />
 
       <ConfirmModal
@@ -268,10 +269,14 @@ const handleCloseNotiModal = () => {
   isFailNoti.value = false;
 }
 
-const handleAddRegion = () => {
+const handleAddRegion = async () => {
   console.log('관심지역 추가');
-  // 실제로는 관심지역 설정 모달 표시 또는 API 호출
-  interestedRegionStore.regions.push(article.value.region);
+  await reloadArticle();
+};
+
+const handleRemoveRegion = async () => {
+  console.log('관심지역 제거');
+  await reloadArticle();
 };
 </script>
 

--- a/src/pages/articleDetail/ArticleDetailPage.vue
+++ b/src/pages/articleDetail/ArticleDetailPage.vue
@@ -21,7 +21,7 @@
       
       <!-- 댓글 섹션 -->
       <CommentSection 
-        :comments="article.comments" 
+        :comments="processedComments" 
         :is-interested-region="isInterestedRegion"
         :current-user-id="Number(member?.id)"
         :current-member-role="member?.role"
@@ -119,6 +119,18 @@ const isInterestedRegion = computed(() => {
 // 좋아요 여부
 const isLiked = computed(() => {
   return article.value.isLiked;
+});
+
+// 관심지역이 아닌 경우 더미 댓글 데이터 생성
+const processedComments = computed(() => {
+  if (isInterestedRegion.value) {
+    return article.value.comments || [];
+  }
+  
+  return article.value.comments.map(() => ({
+    commentContent: '관심지역 설정 후 댓글을 확인할 수 있습니다.',
+    nickname: '익명의 사자',
+  }));
 });
 
 // 게시글 데이터 다시 로드

--- a/src/pages/articleDetail/ArticleDetailPage.vue
+++ b/src/pages/articleDetail/ArticleDetailPage.vue
@@ -104,6 +104,7 @@ onBeforeMount(async () => {
   try {
     await memberStore.getMember();
     article.value = await getArticleDetailApi(articleId);
+    console.log('article', article.value);
   } catch (error) {
     console.error('게시글 상세 조회 실패:', error);
   }
@@ -111,7 +112,7 @@ onBeforeMount(async () => {
 
 // 관심지역인지 여부
 const isInterestedRegion = computed(() => {
-  return interestedRegionStore.regions.find(region => region.boardId === article.value.boardId);
+  return article.value.isInterestedRegion;
 });
 
 // 좋아요 여부

--- a/src/pages/articleDetail/components/CommentSection.vue
+++ b/src/pages/articleDetail/components/CommentSection.vue
@@ -6,6 +6,7 @@
     <RegionNoticeBox 
       v-if="!isInterestedRegion" 
       @add-region="$emit('add-region')" 
+      @remove-region="$emit('remove-region')" 
     />
     
     <!-- 댓글 작성 폼 -->
@@ -72,7 +73,8 @@ const emit = defineEmits([
   'add-reply', 
   'delete-comment', 
   'report-comment', 
-  'add-region'
+  'add-region',
+  'remove-region'
 ]);
 
 const handleCommentSubmit = (content) => {

--- a/src/pages/articleDetail/components/RegionNoticeBox.vue
+++ b/src/pages/articleDetail/components/RegionNoticeBox.vue
@@ -30,6 +30,7 @@ import { useInterestedRegionStore } from "@/features/interestedRegion/interested
 import { addInterestedRegionApi } from '@/entities/interestedRegion/addInterestedRegionApi';
 import { deleteInterestedRegionApi } from '@/entities/interestedRegion/deleteInterestedRegionApi';
 
+const emit = defineEmits(['add-region', 'remove-region']);
 const interestedRegionStore = useInterestedRegionStore();
 const showModal = ref(false);
 const selectedRegions = ref([]);
@@ -45,6 +46,7 @@ const addRegion = async (sggCode) => {
     await addInterestedRegionApi(sggCode);
     await interestedRegionStore.fetchInterestRegions();
     selectedRegions.value = interestedRegionStore.regions;
+    emit('add-region');
   }
 };
 
@@ -56,6 +58,7 @@ const removeRegion = async (sggCode) => {
   await deleteInterestedRegionApi(sggCode);
   await interestedRegionStore.fetchInterestRegions();
   selectedRegions.value = interestedRegionStore.regions;
+  emit('remove-region');
 };
 </script>
 

--- a/src/pages/articleDetail/components/RegionNoticeBox.vue
+++ b/src/pages/articleDetail/components/RegionNoticeBox.vue
@@ -17,33 +17,45 @@
       v-if="showModal"
       :selected-regions="selectedRegions"
       @close="showModal = false"
-      @add-region="handleAddRegion"
-      @remove-region="handleRemoveRegion"
+      @add-region="addRegion"
+      @remove-region="removeRegion"
     />
   </div>
 </template>
 
 <script setup>
-import { ref } from 'vue';
+import { ref, onBeforeMount } from 'vue';
 import RegionSelectModal from '@/pages/board/components/RegionSelectModal.vue';
+import { useInterestedRegionStore } from "@/features/interestedRegion/interestedRegionStore";
+import { addInterestedRegionApi } from '@/entities/interestedRegion/addInterestedRegionApi';
+import { deleteInterestedRegionApi } from '@/entities/interestedRegion/deleteInterestedRegionApi';
 
+const interestedRegionStore = useInterestedRegionStore();
 const showModal = ref(false);
 const selectedRegions = ref([]);
 
+onBeforeMount(async () => {
+  await interestedRegionStore.fetchInterestRegions();
+  selectedRegions.value = interestedRegionStore.regions;
+});
+
 // 지역 추가 핸들러
-const handleAddRegion = (region) => {
-  selectedRegions.value.push(region);
-  // TODO: API 호출하여 관심지역 추가
-  console.log('관심지역 추가:', region);
+const addRegion = async (sggCode) => {
+  if (!selectedRegions.value.some(r => r.code === sggCode)) {
+    await addInterestedRegionApi(sggCode);
+    await interestedRegionStore.fetchInterestRegions();
+    selectedRegions.value = interestedRegionStore.regions;
+  }
 };
 
 // 지역 제거 핸들러
-const handleRemoveRegion = (regionCode) => {
+const removeRegion = async (sggCode) => {
   selectedRegions.value = selectedRegions.value.filter(
-    region => region.code !== regionCode
+    region => region.code !== sggCode
   );
-  // TODO: API 호출하여 관심지역 제거
-  console.log('관심지역 제거:', regionCode);
+  await deleteInterestedRegionApi(sggCode);
+  await interestedRegionStore.fetchInterestRegions();
+  selectedRegions.value = interestedRegionStore.regions;
 };
 </script>
 

--- a/src/pages/board/BoardListPage.vue
+++ b/src/pages/board/BoardListPage.vue
@@ -18,7 +18,6 @@
         />
         
         <!-- 게시판 목록 -->
-         <!-- TODO: 게시글에 조회수 달기 -->
         <div class="board-list" v-if="articles.length > 0">
           <BoardItem
             v-for="(board, index) in articles" 

--- a/src/pages/likedArticle/LikedArticlePage.vue
+++ b/src/pages/likedArticle/LikedArticlePage.vue
@@ -2,12 +2,12 @@
   <div class="liked-article-page">
     <div class="container">      
       <!-- 지역 탭 -->
-      <RegionTabs
+      <!-- <RegionTabs
         :regions="regions"
         :active-region-code="activeRegionCode"
         @select-region="setActiveRegion"
         show-all-tab
-      />
+      /> -->
       
       <!-- 게시글 목록 -->
       <div v-if="filteredArticles.length > 0" class="article-list-container">
@@ -18,7 +18,7 @@
         />
         
         <!-- 페이지네이션 -->
-        <div class="pagination-container" v-if="filteredArticles.length > itemsPerPage">
+        <div class="pagination-container" v-if="totalPages > 1">
           <PaginationBar
             :current-page="currentPage"
             :total-pages="totalPages"
@@ -42,138 +42,48 @@
 </template>
 
 <script setup>
-import { ref, computed } from 'vue';
-import RegionTabs from './components/RegionTabs.vue';
+import { ref, computed, onBeforeMount } from 'vue';
 import ArticleList from './components/ArticleList.vue';
 import EmptyState from './components/EmptyState.vue';
 import PaginationBar from '../../widgets/paginationBar/PaginationBar.vue';
+import { getArticlesApi } from '@/entities/board/getArticlesApi';
+import { useRouter } from 'vue-router';
 
-// 사용자 관심 지역 (실제로는 API에서 가져옴)
-const regions = ref([
-  { code: 'seoul-gangnam', name: '서울시 강남구' },
-  { code: 'seoul-seocho', name: '서울시 서초구' },
-  { code: 'seoul-mapo', name: '서울시 마포구' }
-]);
+const router = useRouter();
+
+onBeforeMount(async () => {
+  console.log('onBeforeMount');
+  await getArticles();
+});
+
+const getArticles = async () => {
+  const response = await getArticlesApi({
+    isLiked: true,
+    page: currentPage.value,
+    size: itemsPerPage
+  });
+  likedArticles.value = response.articles;
+  totalPages.value = response.totalPages;
+};
 
 // 현재 선택된 지역 코드 (기본값: 전체)
 const activeRegionCode = ref('all');
 
-// 좋아요한 게시글 데이터 (실제로는 API에서 가져옴)
-const likedArticles = ref([
-  {
-    id: 1,
-    title: '강남구 맛집 추천 부탁드립니다',
-    content: '강남에 새로 이사왔는데 맛집 추천 부탁드립니다.',
-    author: {
-      id: 101,
-      nickname: '동네주민'
-    },
-    region: 'seoul-gangnam',
-    regionName: '서울시 강남구',
-    createdAt: '2025-05-15T09:30:00Z',
-    viewCount: 128,
-    likeCount: 12,
-    commentCount: 8,
-    likedAt: '2025-05-15T10:15:00Z'
-  },
-  {
-    id: 2,
-    title: '서초구 신축 아파트 정보 있나요?',
-    content: '서초구 신축 아파트 정보 찾고 있습니다.',
-    author: {
-      id: 102,
-      nickname: '집구하는중'
-    },
-    region: 'seoul-seocho',
-    regionName: '서울시 서초구',
-    createdAt: '2025-05-14T14:20:00Z',
-    viewCount: 95,
-    likeCount: 7,
-    commentCount: 4,
-    likedAt: '2025-05-14T15:30:00Z'
-  },
-  {
-    id: 3,
-    title: '강남역 근처 주차장 정보 공유합니다',
-    content: '강남역 근처 저렴한 주차장 정보 공유합니다.',
-    author: {
-      id: 103,
-      nickname: '주차달인'
-    },
-    region: 'seoul-gangnam',
-    regionName: '서울시 강남구',
-    createdAt: '2025-05-13T11:45:00Z',
-    viewCount: 76,
-    likeCount: 5,
-    commentCount: 3,
-    likedAt: '2025-05-13T12:10:00Z'
-  },
-  {
-    id: 4,
-    title: '마포구 한강공원 러닝 모임 있나요?',
-    content: '마포구 한강공원에서 함께 러닝할 모임을 찾고 있습니다.',
-    author: {
-      id: 104,
-      nickname: '러닝러버'
-    },
-    region: 'seoul-mapo',
-    regionName: '서울시 마포구',
-    createdAt: '2025-05-12T08:30:00Z',
-    viewCount: 112,
-    likeCount: 9,
-    commentCount: 6,
-    likedAt: '2025-05-12T09:15:00Z'
-  },
-  {
-    id: 5,
-    title: '서초구 반려동물 동반 카페 추천',
-    content: '강아지와 함께 갈 수 있는 카페 추천 부탁드립니다.',
-    author: {
-      id: 105,
-      nickname: '강아지맘'
-    },
-    region: 'seoul-seocho',
-    regionName: '서울시 서초구',
-    createdAt: '2025-05-11T16:20:00Z',
-    viewCount: 143,
-    likeCount: 15,
-    commentCount: 9,
-    likedAt: '2025-05-11T17:05:00Z'
-  },
-  {
-    id: 6,
-    title: '마포구 홍대 근처 스터디 카페 추천해주세요',
-    content: '홍대 근처에서 조용하고 집중하기 좋은 스터디 카페 추천 부탁드립니다.',
-    author: {
-      id: 106,
-      nickname: '대학생'
-    },
-    region: 'seoul-mapo',
-    regionName: '서울시 마포구',
-    createdAt: '2025-05-10T13:10:00Z',
-    viewCount: 88,
-    likeCount: 6,
-    commentCount: 5,
-    likedAt: '2025-05-10T14:25:00Z'
-  }
-]);
+// 좋아요한 게시글 데이터
+const likedArticles = ref([]);
 
 // 페이지네이션 관련 상태
 const currentPage = ref(1);
 const itemsPerPage = 5;
+const totalPages = ref(0);
 
 // 선택된 지역에 따라 필터링된 게시글 목록
 const filteredArticles = computed(() => {
+  console.log('filteredArticles', likedArticles.value);
   if (activeRegionCode.value === 'all') {
     return likedArticles.value;
   }
   return likedArticles.value.filter(article => article.region === activeRegionCode.value);
-});
-
-// 총 페이지 수 계산
-const totalPages = computed(() => {
-  const filteredCount = filteredArticles.value.length;
-  return Math.ceil(filteredCount / itemsPerPage);
 });
 
 // 현재 페이지에 표시할 게시글 목록
@@ -207,9 +117,10 @@ const setActiveRegion = (regionCode) => {
 };
 
 // 페이지 이동
-const goToPage = (page) => {
+const goToPage = async (page) => {
   if (page >= 1 && page <= totalPages.value) {
     currentPage.value = page;
+    await getArticles();
     // 페이지 상단으로 스크롤
     window.scrollTo({ top: 0, behavior: 'smooth' });
   }
@@ -217,9 +128,7 @@ const goToPage = (page) => {
 
 // 게시글 상세 페이지로 이동
 const goToArticleDetail = (articleId) => {
-  console.log(`게시글 상세 페이지로 이동: ${articleId}`);
-  // 실제로는 라우터 사용
-  // router.push(`/article/${articleId}`);
+  router.push(`/board/article/${articleId}`);
 };
 
 // 게시글 좋아요 취소
@@ -233,9 +142,7 @@ const unlikeArticle = (articleId) => {
 
 // 게시판 목록으로 이동
 const goToBoardList = () => {
-  console.log('게시판 목록으로 이동');
-  // 실제로는 라우터 사용
-  // router.push('/board');
+  router.push({ name: 'boardList' });
 };
 </script>
 

--- a/src/pages/likedArticle/components/ArticleItem.vue
+++ b/src/pages/likedArticle/components/ArticleItem.vue
@@ -5,7 +5,7 @@
 
     <div class="article-meta">
       <div class="meta-left">
-        <span class="author">{{ article.author.nickname }}</span>
+        <span class="author">{{ article.nickname }}</span>
         <span class="separator">·</span>
         <span class="date">{{ formatDate(article.createdAt) }}</span>
       </div>
@@ -72,25 +72,6 @@
           <span>{{ article.commentCount }}</span>
         </div>
       </div>
-    </div>
-
-    <div class="article-actions">
-      <div class="liked-info">
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="16"
-          height="16"
-          viewBox="0 0 24 24"
-          fill="currentColor"
-          class="liked-icon"
-        >
-          <path
-            d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z"
-          />
-        </svg>
-        <span>{{ formatDate(article.likedAt) }}에 좋아요</span>
-      </div>
-      <button @click.stop="$emit('unlike-article', article.id)" class="unlike-button">좋아요 취소</button>
     </div>
   </div>
 </template>

--- a/src/pages/my/MyPage.vue
+++ b/src/pages/my/MyPage.vue
@@ -133,7 +133,7 @@ const navigateToPasswordUpdate = () => {
 };
 
 const navigateToFavorites = () => {
-  router.push({ name: 'articleLike' });
+  router.push({ name: 'articleLiked' });
 };
 
 const navigateToInterestAreas = () => {


### PR DESCRIPTION
### 작업 내용
마이페이지 하위 메뉴인 좋아요한 게시글 페이지와 api 를 연결하였습니다.

### 리뷰어 참고 & 요구 사항
- 지역별 구분 없이, 좋아요한 게시글의 전체 목록이 표시됩니다.
- 관심지역이 아닌 게시글의 경우 댓글이 블러 처리되며, 관심지역으로 설정하는 버튼이 표시됩니다.

### 현재 버그
- 게시글 단건 조회 결과에 포함된 isInterestedRegion (T / F) 필드로 댓글 블러 여부를 처리합니다.
- 따라서, 게시글 페이지에서 관심지역으로 변경 시 블러 여부가 바로 반영되지 않고 게시글을 다시 로드(api 호출) 해야 반영됩니다.

### 페어 리뷰 요청사항
현재 관심지역 변경 시 댓글 블러 처리가 즉시 반영되지 않는 문제가 있습니다. 
이 문제를 해결하기 위해 어떤 접근 방식을 사용하는 것이 좋을지 의견을 부탁드립니다:

1. **관심지역 변경 시 게시글을 다시 로드하는 방식**: 관심지역이 변경되면 게시글 API를 다시 호출하여 isInterestedRegion 필드를 업데이트
2. **클라이언트에서 실시간으로 블러 상태를 계산하는 방식**: 관심지역 변경 시 서버 API 호출 없이 클라이언트에서 현재 관심지역 목록과 게시글의 지역을 비교하여 블러 상태를 즉시 업데이트
   - **필요한 API 수정사항**: 게시글 응답에 `sggCode` 필드 추가 필요

첫 번째 방식은 불필요한 API 호출이 많아질 것 같아서 두 번째 방식이 더 적절하다고 생각합니다. 
클라이언트에서 실시간으로 블러 상태를 계산하는 방식이 사용자 경험 측면에서도 더 부드럽고, 서버 부하도 줄일 수 있을 것 같습니다. 

### 관련 이슈
x